### PR TITLE
Remove console.log in downloader

### DIFF
--- a/src/geoip2-cli.downloader.ts
+++ b/src/geoip2-cli.downloader.ts
@@ -42,8 +42,6 @@ export class Geoip2CliDownloader {
     const link = 'https://download.maxmind.com/app/geoip_download';
     const url = `${link}?license_key=${licenseKey}&edition_id=${EDITIONS[edition]}&date=${date}&suffix=tar.gz`;
 
-    console.log(url);
-
     return await new Promise(resolve => {
       https.get(url, response => {
         response


### PR DESCRIPTION
Currently, the downloader prints the download URL (containing the license key!) to the log. This is fine for the CLI, but is potentially undesirable when used programatically.