### PR TITLE
Resolve downloader on pipe finish

### DIFF
--- a/src/geoip2-cli.downloader.ts
+++ b/src/geoip2-cli.downloader.ts
@@ -44,15 +44,16 @@ export class Geoip2CliDownloader {
 
     console.log(url);
 
-    return await new Promise(resolve => {
+    return await new Promise((resolve, reject) => {
       https.get(url, response => {
         response
         .pipe(zlib.createGunzip().on('error', () => console.log('Link not found. Invalid licenseKey?')))
         .pipe(tar.t()).on('entry', (entry: any) => {
           if (entry.path.endsWith('.mmdb')) {
             const dstFilename = path.join(downloadPath, path.basename(entry.path));
-            entry.pipe(fs.createWriteStream(dstFilename));
-            resolve(dstFilename);
+            entry.pipe(fs.createWriteStream(dstFilename))
+              .on('finish', () => resolve(dstFilename))
+              .on('error', reject);
           }
         });
       });


### PR DESCRIPTION
Apologies, I should've bundled this in with my last PR. I ran into this bug when trying to get the mmdb filesize with `fs.stat` immediately after downloading the database. Turns out, the promise was not being resolved when the file had finished writing, rather, only when it had started writing. This patch fixes that.